### PR TITLE
Update README.md to include instructions for making native app multi-tenant

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ The Windows Store application shows how to handle in-up sign up for a new servic
 
 For more information about how the protocols work in this scenario and other scenarios, see [Authentication Scenarios for Azure AD](https://azure.microsoft.com/documentation/articles/active-directory-authentication-scenarios/).
 
+> Looking for previous versions of this code sample? Check out the tags on the [releases](../../releases) GitHub page.
+
 ## How To Run This Sample
 
 To run this sample you will need:

--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ There are two projects in this sample.  Each needs to be separately registered i
 
 1. Sign in to the [Azure portal](https://portal.azure.com).
 2. On the top bar, click on your account and under the **Directory** list, choose the Active Directory tenant where you wish to register your application.
-2. Click on **More Services** in the left hand nav, and choose **Azure Active Directory**.
-3. Click on **Registered Applications** and choose **Add**.
-4. Enter a friendly name for the application, for example 'TodoListServiceMT' and select 'Web Application and/or Web API' as the Application Type. For the sign-on URL, enter the base URL for the sample, which is by default `https://localhost:44321`. Click on **Create** to create the application.
-5. While still in the Azure portal, choose your application, click on **Settings** and choose **Properties**.
-6. Find the Application ID value and copy it to the clipboard.
-7. Find "multitenanted" switch and flip it to yes. Hit the Save button from the command bar.
+3. Click on **More Services** in the left hand nav, and choose **Azure Active Directory**.
+4. Click on **App registrations** and choose **Add**.
+5. Enter a friendly name for the application, for example 'TodoListServiceMT' and select 'Web Application and/or Web API' as the Application Type. For the sign-on URL, enter the base URL for the sample, which is by default `https://localhost:44321`. Click on **Create** to create the application.
+6. While still in the Azure portal, choose your application, click on **Settings** and choose **Properties**.
+7. Find the Application ID value and copy it to the clipboard.
+8. Find "multitenanted" switch and flip it to yes. Hit the Save button from the command bar.
 
 #### Find the TodoListClient app's redirect URI
 
@@ -77,7 +77,7 @@ ms-app://s-1-15-2-2123189467-1366327299-2057240504-936110431-2588729968-14545362
 1. Sign in to the [Azure portal](https://portal.azure.com).
 2. On the top bar, click on your account and under the **Directory** list, choose the Active Directory tenant where you wish to register your application.
 2. Click on **More Services** in the left hand nav, and choose **Azure Active Directory**.
-3. Click on **Registered Applications** and choose **Add**.
+3. Click on **App registrations** and choose **Add**.
 4. Enter a friendly name for the application, for example 'TodoListClient-WindowsStore' and select 'Native' as the Application Type. Enter the Redirect URI value that you obtained during the previous step. Click on **Create** to create the application.
 5. While still in the Azure portal, choose your application, click on **Settings** and choose **Properties**.
 6. Find the Application ID value and copy it to the clipboard.

--- a/README.md
+++ b/README.md
@@ -20,10 +20,9 @@ To run this sample you will need:
 - Visual Studio 2015
 - Windows 10
 - An Internet connection
-- An Azure subscription (a free trial is sufficient)
 - A Microsoft account
-
-Every Azure subscription has an associated Azure Active Directory tenant.  If you don't already have an Azure subscription, you can get a free subscription by signing up at [http://wwww.windowsazure.com](http://www.windowsazure.com).  All of the Azure AD features used by this sample are available free of charge.
+- An Azure Active Directory (Azure AD) tenant. For more information on how to get an Azure AD tenant, please see [How to get an Azure AD tenant](https://azure.microsoft.com/en-us/documentation/articles/active-directory-howto-tenant/) 
+- A user account in your Azure AD tenant. This sample will not work with a Microsoft account, so if you signed in to the Azure portal with a Microsoft account and have never created a user account in your directory before, you need to do that now.
 
 ### Step 1:  Clone or download this repository
 
@@ -31,11 +30,7 @@ From your shell or command line:
 
 `git clone https://github.com/Azure-Samples/active-directory-dotnet-webapi-multitenant-windows-store.git`
 
-### Step 2:  Create a user account in your Azure Active Directory tenant
-
-If you already have a user account in your Azure Active Directory tenant, you can skip to the next step.  This sample will not work with a Microsoft account, so if you signed in to the Azure portal with a Microsoft account and have never created a user account in your directory before, you need to do that now.  If you create an account and want to use it to sign-in to the Azure portal, don't forget to add the user account as a co-administrator of your Azure subscription.
-
-### Step 3:  Register the sample with your Azure Active Directory tenant
+### Step 2:  Register the sample with your Azure Active Directory tenant
 
 There are two projects in this sample.  Each needs to be separately registered in your Azure AD tenant.
 
@@ -83,7 +78,7 @@ ms-app://s-1-15-2-2123189467-1366327299-2057240504-936110431-2588729968-14545362
 6. Find the Application ID value and copy it to the clipboard.
 7. Configure Permissions for your application - in the Settings menu, choose the 'Required permissions' section, click on **Add**, then **Select an API**, and type 'TodoListServiceMT' in the textbox. Then, click on  **Select Permissions** and select 'Access TodoListServiceMT'.
 
-### Step 4: Add the client application to the known clients list of the API 
+### Step 3: Add the client application to the known clients list of the API 
 
 For the client application to be able to call the web API from a tenant other than the one where you developed the app, you need to explicitly bind the client app registration in Azure AD with the registration for the web API. You can do so by adding the "Client ID" of the client app, to the manifest of the web API. Here's how:
 
@@ -99,7 +94,7 @@ For the client application to be able to call the web API from a tenant other th
     5. click the "Manage Manifest" option at the bottom of the page, and select "Upload Manifest"
     6. browse to the text file you updated in step 2 and upload it
 
-### Step 5:  Configure the sample to use your Azure AD tenant
+### Step 4:  Configure the sample to use your Azure AD tenant
 
 #### Configure the TodoListServiceMT project
 
@@ -115,7 +110,7 @@ For the client application to be able to call the web API from a tenant other th
 3. Find the declaration of `clientId` and replace the value with the Client ID from the Azure portal.
 4. Find the declaration of `ResourceID` and `APIHostname` and ensure their values are set properly for your TodoListService project.
 
-### Step 6:  Trust the IIS Express SSL certificate
+### Step 5:  Trust the IIS Express SSL certificate
 
 Since the web API is SSL protected, the client of the API (the web app) will refuse the SSL connection to the web API unless it trusts the API's SSL certificate.  Use the following steps in Windows Powershell to trust the IIS Express SSL certificate.  You only need to do this once.  If you fail to do this step, calls to the TodoListServiceMT will always throw an unhandled exception where the inner exception message is:
 
@@ -152,11 +147,11 @@ You can verify the certificate is in the Trusted Root store by running this comm
 `PS C:\windows\system32> dir Cert:\LocalMachine\Root`
 
 
-### Step 7:  [optional] Create an Azure Active Directory test tenant
+### Step 6:  [optional] Create an Azure Active Directory test tenant
 
 This sample shows how to take advantage of the consent model in Azure AD to make a web API available to native clients ran by any user from any organization with a tenant in Azure AD. To see that part of the sample in action, you need to have access to user accounts from a tenant that is different from the one you used for developing the application. The simplest way of doing that is to create a new directory tenant in your Azure subscription (just navigate to the main Active Directory page in the portal and click Add) and add test users. This step is optional as you can also run the sample with accounts from the same directory, but if you do you will not see the consent prompts as the app is already approved. 
 
-### Step 8:  Run the sample
+### Step 7:  Run the sample
 
 Clean the solution, rebuild the solution, and run it.  You might want to go into the solution properties and set both projects as startup projects, with the service project starting first.
 

--- a/README.md
+++ b/README.md
@@ -41,18 +41,14 @@ There are two projects in this sample.  Each needs to be separately registered i
 
 #### Register the TodoListServiceMT web API
 
-1. Sign in to the [Azure management portal](https://manage.windowsazure.com).
-2. Click on Active Directory in the left hand nav.
-3. Click the directory tenant where you wish to register the sample application.
-4. Click the Applications tab.
-5. In the drawer, click Add.
-6. Click "Add an application my organization is developing".
-7. Enter a friendly name for the application, for example "TodoListServiceMT", select "Web Application and/or Web API", and click next.
-8. For the sign-on URL, enter the base URL for the sample, which is by default `https://localhost:44321`.
-9. For the App ID URI, enter `https://<your_tenant_name>/TodoListServiceMT`, replacing `<your_tenant_name>` with the name of your Azure AD tenant.  Click OK to complete the registration.
-10. While still in the Azure portal, click the Configure tab of your application.
-11. Find the Client ID value and copy it aside, you will need this later when configuring your application.
-12. Find "the application is multi-tenant" switch and flip it to yes. Hit the Save button from the command bar.
+1. Sign in to the [Azure portal](https://portal.azure.com).
+2. On the top bar, click on your account and under the **Directory** list, choose the Active Directory tenant where you wish to register your application.
+2. Click on **More Services** in the left hand nav, and choose **Azure Active Directory**.
+3. Click on **Registered Applications** and choose **Add**.
+4. Enter a friendly name for the application, for example 'TodoListServiceMT' and select 'Web Application and/or Web API' as the Application Type. For the sign-on URL, enter the base URL for the sample, which is by default `https://localhost:44321`. Click on **Create** to create the application.
+5. While still in the Azure portal, choose your application, click on **Settings** and choose **Properties**.
+6. Find the Application ID value and copy it to the clipboard.
+7. Find "multitenanted" switch and flip it to yes. Hit the Save button from the command bar.
 
 #### Find the TodoListClient app's redirect URI
 
@@ -78,17 +74,14 @@ ms-app://s-1-15-2-2123189467-1366327299-2057240504-936110431-2588729968-14545362
 
 #### Register the TodoListClient app
 
-1. Sign in to the [Azure management portal](https://manage.windowsazure.com).
-2. Click on Active Directory in the left hand nav.
-3. Click the directory tenant where you wish to register the sample application.
-4. Click the Applications tab.
-5. In the drawer, click Add.
-6. Click "Add an application my organization is developing".
-7. Enter a friendly name for the application, for example "TodoListClient-WindowsStore", select "Native Client Application", and click next.
-8. Enter the Redirect URI value that you obtained during the previous step.  Click finish.
-9. Click the Configure tab of the application.
-10. Find the Client ID value and copy it aside, you will need this later when configuring your application.
-11. In "Permissions to Other Applications", click "Add Application."  Select "Other" in the "Show" dropdown, and click the upper check mark.  Locate & click on the TodoListService, and click the bottom check mark to add the application.  Select "Access TodoListServiceMT" from the "Delegated Permissions" dropdown, and save the configuration.
+1. Sign in to the [Azure portal](https://portal.azure.com).
+2. On the top bar, click on your account and under the **Directory** list, choose the Active Directory tenant where you wish to register your application.
+2. Click on **More Services** in the left hand nav, and choose **Azure Active Directory**.
+3. Click on **Registered Applications** and choose **Add**.
+4. Enter a friendly name for the application, for example 'TodoListClient-WindowsStore' and select 'Native' as the Application Type. Enter the Redirect URI value that you obtained during the previous step. Click on **Create** to create the application.
+5. While still in the Azure portal, choose your application, click on **Settings** and choose **Properties**.
+6. Find the Application ID value and copy it to the clipboard.
+7. Configure Permissions for your application - in the Settings menu, choose the 'Required permissions' section, click on **Add**, then **Select an API**, and type 'TodoListServiceMT' in the textbox. Then, click on  **Select Permissions** and select 'Access TodoListServiceMT'.
 
 ### Step 4: Add the client application to the known clients list of the API 
 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ To run this sample you will need:
 - Visual Studio 2015
 - Windows 10
 - An Internet connection
+- An Azure subscription (a free trial is sufficient)
 - A Microsoft account
-- An Azure Active Directory (Azure AD) tenant. For more information on how to get an Azure AD tenant, please see [How to get an Azure AD tenant](https://azure.microsoft.com/en-us/documentation/articles/active-directory-howto-tenant/) 
-- A user account in your Azure AD tenant. This sample will not work with a Microsoft account, so if you signed in to the Azure portal with a Microsoft account and have never created a user account in your directory before, you need to do that now.
+
+Every Azure subscription has an associated Azure Active Directory tenant.  If you don't already have an Azure subscription, you can get a free subscription by signing up at [http://wwww.windowsazure.com](http://www.windowsazure.com).  All of the Azure AD features used by this sample are available free of charge.
 
 ### Step 1:  Clone or download this repository
 
@@ -30,20 +31,28 @@ From your shell or command line:
 
 `git clone https://github.com/Azure-Samples/active-directory-dotnet-webapi-multitenant-windows-store.git`
 
-### Step 2:  Register the sample with your Azure Active Directory tenant
+### Step 2:  Create a user account in your Azure Active Directory tenant
+
+If you already have a user account in your Azure Active Directory tenant, you can skip to the next step.  This sample will not work with a Microsoft account, so if you signed in to the Azure portal with a Microsoft account and have never created a user account in your directory before, you need to do that now.  If you create an account and want to use it to sign-in to the Azure portal, don't forget to add the user account as a co-administrator of your Azure subscription.
+
+### Step 3:  Register the sample with your Azure Active Directory tenant
 
 There are two projects in this sample.  Each needs to be separately registered in your Azure AD tenant.
 
 #### Register the TodoListServiceMT web API
 
-1. Sign in to the [Azure portal](https://portal.azure.com).
-2. On the top bar, click on your account and under the **Directory** list, choose the Active Directory tenant where you wish to register your application.
-3. Click on **More Services** in the left hand nav, and choose **Azure Active Directory**.
-4. Click on **App registrations** and choose **Add**.
-5. Enter a friendly name for the application, for example 'TodoListServiceMT' and select 'Web Application and/or Web API' as the Application Type. For the sign-on URL, enter the base URL for the sample, which is by default `https://localhost:44321`. Click on **Create** to create the application.
-6. While still in the Azure portal, choose your application, click on **Settings** and choose **Properties**.
-7. Find the Application ID value and copy it to the clipboard.
-8. Find "multitenanted" switch and flip it to yes. Hit the Save button from the command bar.
+1. Sign in to the [Azure management portal](https://manage.windowsazure.com).
+2. Click on Active Directory in the left hand nav.
+3. Click the directory tenant where you wish to register the sample application.
+4. Click the Applications tab.
+5. In the drawer, click Add.
+6. Click "Add an application my organization is developing".
+7. Enter a friendly name for the application, for example "TodoListServiceMT", select "Web Application and/or Web API", and click next.
+8. For the sign-on URL, enter the base URL for the sample, which is by default `https://localhost:44321`.
+9. For the App ID URI, enter `https://<your_tenant_name>/TodoListServiceMT`, replacing `<your_tenant_name>` with the name of your Azure AD tenant.  Click OK to complete the registration.
+10. While still in the Azure portal, click the Configure tab of your application.
+11. Find the Client ID value and copy it aside, you will need this later when configuring your application.
+12. Find "the application is multi-tenant" switch and flip it to yes. Hit the Save button from the command bar.
 
 #### Find the TodoListClient app's redirect URI
 
@@ -69,16 +78,19 @@ ms-app://s-1-15-2-2123189467-1366327299-2057240504-936110431-2588729968-14545362
 
 #### Register the TodoListClient app
 
-1. Sign in to the [Azure portal](https://portal.azure.com).
-2. On the top bar, click on your account and under the **Directory** list, choose the Active Directory tenant where you wish to register your application.
-2. Click on **More Services** in the left hand nav, and choose **Azure Active Directory**.
-3. Click on **App registrations** and choose **Add**.
-4. Enter a friendly name for the application, for example 'TodoListClient-WindowsStore' and select 'Native' as the Application Type. Enter the Redirect URI value that you obtained during the previous step. Click on **Create** to create the application.
-5. While still in the Azure portal, choose your application, click on **Settings** and choose **Properties**.
-6. Find the Application ID value and copy it to the clipboard.
-7. Configure Permissions for your application - in the Settings menu, choose the 'Required permissions' section, click on **Add**, then **Select an API**, and type 'TodoListServiceMT' in the textbox. Then, click on  **Select Permissions** and select 'Access TodoListServiceMT'.
+1. Sign in to the [Azure management portal](https://manage.windowsazure.com).
+2. Click on Active Directory in the left hand nav.
+3. Click the directory tenant where you wish to register the sample application.
+4. Click the Applications tab.
+5. In the drawer, click Add.
+6. Click "Add an application my organization is developing".
+7. Enter a friendly name for the application, for example "TodoListClient-WindowsStore", select "Native Client Application", and click next.
+8. Enter the Redirect URI value that you obtained during the previous step.  Click finish.
+9. Click the Configure tab of the application.
+10. Find the Client ID value and copy it aside, you will need this later when configuring your application.
+11. In "Permissions to Other Applications", click "Add Application."  Select "Other" in the "Show" dropdown, and click the upper check mark.  Locate & click on the TodoListService, and click the bottom check mark to add the application.  Select "Access TodoListServiceMT" from the "Delegated Permissions" dropdown, and save the configuration.
 
-### Step 3: Add the client application to the known clients list of the API 
+### Step 4: Add the client application to the known clients list of the API 
 
 For the client application to be able to call the web API from a tenant other than the one where you developed the app, you need to explicitly bind the client app registration in Azure AD with the registration for the web API. You can do so by adding the "Client ID" of the client app, to the manifest of the web API. Here's how:
 
@@ -94,7 +106,7 @@ For the client application to be able to call the web API from a tenant other th
     5. click the "Manage Manifest" option at the bottom of the page, and select "Upload Manifest"
     6. browse to the text file you updated in step 2 and upload it
 
-### Step 4:  Configure the sample to use your Azure AD tenant
+### Step 5:  Configure the sample to use your Azure AD tenant
 
 #### Configure the TodoListServiceMT project
 
@@ -110,7 +122,7 @@ For the client application to be able to call the web API from a tenant other th
 3. Find the declaration of `clientId` and replace the value with the Client ID from the Azure portal.
 4. Find the declaration of `ResourceID` and `APIHostname` and ensure their values are set properly for your TodoListService project.
 
-### Step 5:  Trust the IIS Express SSL certificate
+### Step 6:  Trust the IIS Express SSL certificate
 
 Since the web API is SSL protected, the client of the API (the web app) will refuse the SSL connection to the web API unless it trusts the API's SSL certificate.  Use the following steps in Windows Powershell to trust the IIS Express SSL certificate.  You only need to do this once.  If you fail to do this step, calls to the TodoListServiceMT will always throw an unhandled exception where the inner exception message is:
 
@@ -147,11 +159,11 @@ You can verify the certificate is in the Trusted Root store by running this comm
 `PS C:\windows\system32> dir Cert:\LocalMachine\Root`
 
 
-### Step 6:  [optional] Create an Azure Active Directory test tenant
+### Step 7:  [optional] Create an Azure Active Directory test tenant
 
 This sample shows how to take advantage of the consent model in Azure AD to make a web API available to native clients ran by any user from any organization with a tenant in Azure AD. To see that part of the sample in action, you need to have access to user accounts from a tenant that is different from the one you used for developing the application. The simplest way of doing that is to create a new directory tenant in your Azure subscription (just navigate to the main Active Directory page in the portal and click Add) and add test users. This step is optional as you can also run the sample with accounts from the same directory, but if you do you will not see the consent prompts as the app is already approved. 
 
-### Step 7:  Run the sample
+### Step 8:  Run the sample
 
 Clean the solution, rebuild the solution, and run it.  You might want to go into the solution properties and set both projects as startup projects, with the service project starting first.
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,17 @@ ms-app://s-1-15-2-2123189467-1366327299-2057240504-936110431-2588729968-14545362
 4. Enter a friendly name for the application, for example 'TodoListClient-WindowsStore' and select 'Native' as the Application Type. Enter the Redirect URI value that you obtained during the previous step. Click on **Create** to create the application.
 5. While still in the Azure portal, choose your application, click on **Settings** and choose **Properties**.
 6. Find the Application ID value and copy it to the clipboard.
-7. Configure Permissions for your application - in the Settings menu, choose the 'Required permissions' section, click on **Add**, then **Select an API**, and type 'TodoListServiceMT' in the textbox. Then, click on  **Select Permissions** and select 'Access TodoListServiceMT'.
+7. Configure Permissions for your client application to access the service
+	1. In the Settings menu, choose the 'Required permissions' section
+	2. Click on **Add**, then click on **Select an API**
+	3. Type 'TodoListServiceMT' in the textbox.
+	4. Click on **Select Permissions**
+	5. Select 'Access TodoListServiceMT'
+8. Enable your native app for mulitenancy
+	1. From the app details, click the 'Manifest' option
+	2. Click **Edit**
+	3. Change the value of `availableToOtherTenants` to `true`.
+	4. Click **Save**
 
 ### Step 3: Add the client application to the known clients list of the API 
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ For more information about how the protocols work in this scenario and other sce
 ## How To Run This Sample
 
 To run this sample you will need:
-- Visual Studio 2013
-- Windows 8.1 or higher
+- Visual Studio 2015
+- Windows 10
 - An Internet connection
 - An Azure subscription (a free trial is sufficient)
 - A Microsoft account
@@ -110,7 +110,7 @@ For the client application to be able to call the web API from a tenant other th
 
 #### Configure the TodoListServiceMT project
 
-1. Open the solution in Visual Studio 2013.
+1. Open the solution in Visual Studio 2015.
 2. Open the `web.config` file.
 3. Find the app key `ida:Tenant` and replace the value with your AAD tenant name.
 4. Find the app key `ida:Audience` and replace the value with the App ID URI you registered earlier, for example `https://<your_tenant_name>/TodoListServiceMT`.

--- a/README.md
+++ b/README.md
@@ -20,10 +20,9 @@ To run this sample you will need:
 - Visual Studio 2015
 - Windows 10
 - An Internet connection
-- An Azure subscription (a free trial is sufficient)
 - A Microsoft account
-
-Every Azure subscription has an associated Azure Active Directory tenant.  If you don't already have an Azure subscription, you can get a free subscription by signing up at [http://wwww.windowsazure.com](http://www.windowsazure.com).  All of the Azure AD features used by this sample are available free of charge.
+- An Azure Active Directory (Azure AD) tenant. For more information on how to get an Azure AD tenant, please see [How to get an Azure AD tenant](https://azure.microsoft.com/en-us/documentation/articles/active-directory-howto-tenant/) 
+- A user account in your Azure AD tenant. This sample will not work with a Microsoft account, so if you signed in to the Azure portal with a Microsoft account and have never created a user account in your directory before, you need to do that now.
 
 ### Step 1:  Clone or download this repository
 
@@ -31,28 +30,20 @@ From your shell or command line:
 
 `git clone https://github.com/Azure-Samples/active-directory-dotnet-webapi-multitenant-windows-store.git`
 
-### Step 2:  Create a user account in your Azure Active Directory tenant
-
-If you already have a user account in your Azure Active Directory tenant, you can skip to the next step.  This sample will not work with a Microsoft account, so if you signed in to the Azure portal with a Microsoft account and have never created a user account in your directory before, you need to do that now.  If you create an account and want to use it to sign-in to the Azure portal, don't forget to add the user account as a co-administrator of your Azure subscription.
-
-### Step 3:  Register the sample with your Azure Active Directory tenant
+### Step 2:  Register the sample with your Azure Active Directory tenant
 
 There are two projects in this sample.  Each needs to be separately registered in your Azure AD tenant.
 
 #### Register the TodoListServiceMT web API
 
-1. Sign in to the [Azure management portal](https://manage.windowsazure.com).
-2. Click on Active Directory in the left hand nav.
-3. Click the directory tenant where you wish to register the sample application.
-4. Click the Applications tab.
-5. In the drawer, click Add.
-6. Click "Add an application my organization is developing".
-7. Enter a friendly name for the application, for example "TodoListServiceMT", select "Web Application and/or Web API", and click next.
-8. For the sign-on URL, enter the base URL for the sample, which is by default `https://localhost:44321`.
-9. For the App ID URI, enter `https://<your_tenant_name>/TodoListServiceMT`, replacing `<your_tenant_name>` with the name of your Azure AD tenant.  Click OK to complete the registration.
-10. While still in the Azure portal, click the Configure tab of your application.
-11. Find the Client ID value and copy it aside, you will need this later when configuring your application.
-12. Find "the application is multi-tenant" switch and flip it to yes. Hit the Save button from the command bar.
+1. Sign in to the [Azure portal](https://portal.azure.com).
+2. On the top bar, click on your account and under the **Directory** list, choose the Active Directory tenant where you wish to register your application.
+3. Click on **More Services** in the left hand nav, and choose **Azure Active Directory**.
+4. Click on **App registrations** and choose **Add**.
+5. Enter a friendly name for the application, for example 'TodoListServiceMT' and select 'Web Application and/or Web API' as the Application Type. For the sign-on URL, enter the base URL for the sample, which is by default `https://localhost:44321`. For the App ID URI, enter https://<your_tenant_name>/TodoListServiceMT, replacing <your_tenant_name> with the name of your Azure AD tenant. Click on **Create** to create the application.
+6. While still in the Azure portal, choose your application, click on **Settings** and choose **Properties**.
+7. Find the Application ID value and copy it to the clipboard.
+8. Find "multitenanted" switch and flip it to yes. Hit the Save button from the command bar.
 
 #### Find the TodoListClient app's redirect URI
 
@@ -78,19 +69,16 @@ ms-app://s-1-15-2-2123189467-1366327299-2057240504-936110431-2588729968-14545362
 
 #### Register the TodoListClient app
 
-1. Sign in to the [Azure management portal](https://manage.windowsazure.com).
-2. Click on Active Directory in the left hand nav.
-3. Click the directory tenant where you wish to register the sample application.
-4. Click the Applications tab.
-5. In the drawer, click Add.
-6. Click "Add an application my organization is developing".
-7. Enter a friendly name for the application, for example "TodoListClient-WindowsStore", select "Native Client Application", and click next.
-8. Enter the Redirect URI value that you obtained during the previous step.  Click finish.
-9. Click the Configure tab of the application.
-10. Find the Client ID value and copy it aside, you will need this later when configuring your application.
-11. In "Permissions to Other Applications", click "Add Application."  Select "Other" in the "Show" dropdown, and click the upper check mark.  Locate & click on the TodoListService, and click the bottom check mark to add the application.  Select "Access TodoListServiceMT" from the "Delegated Permissions" dropdown, and save the configuration.
+1. Sign in to the [Azure portal](https://portal.azure.com).
+2. On the top bar, click on your account and under the **Directory** list, choose the Active Directory tenant where you wish to register your application.
+2. Click on **More Services** in the left hand nav, and choose **Azure Active Directory**.
+3. Click on **App registrations** and choose **Add**.
+4. Enter a friendly name for the application, for example 'TodoListClient-WindowsStore' and select 'Native' as the Application Type. Enter the Redirect URI value that you obtained during the previous step. Click on **Create** to create the application.
+5. While still in the Azure portal, choose your application, click on **Settings** and choose **Properties**.
+6. Find the Application ID value and copy it to the clipboard.
+7. Configure Permissions for your application - in the Settings menu, choose the 'Required permissions' section, click on **Add**, then **Select an API**, and type 'TodoListServiceMT' in the textbox. Then, click on  **Select Permissions** and select 'Access TodoListServiceMT'.
 
-### Step 4: Add the client application to the known clients list of the API 
+### Step 3: Add the client application to the known clients list of the API 
 
 For the client application to be able to call the web API from a tenant other than the one where you developed the app, you need to explicitly bind the client app registration in Azure AD with the registration for the web API. You can do so by adding the "Client ID" of the client app, to the manifest of the web API. Here's how:
 
@@ -106,7 +94,7 @@ For the client application to be able to call the web API from a tenant other th
     5. click the "Manage Manifest" option at the bottom of the page, and select "Upload Manifest"
     6. browse to the text file you updated in step 2 and upload it
 
-### Step 5:  Configure the sample to use your Azure AD tenant
+### Step 4:  Configure the sample to use your Azure AD tenant
 
 #### Configure the TodoListServiceMT project
 
@@ -122,7 +110,7 @@ For the client application to be able to call the web API from a tenant other th
 3. Find the declaration of `clientId` and replace the value with the Client ID from the Azure portal.
 4. Find the declaration of `ResourceID` and `APIHostname` and ensure their values are set properly for your TodoListService project.
 
-### Step 6:  Trust the IIS Express SSL certificate
+### Step 5:  Trust the IIS Express SSL certificate
 
 Since the web API is SSL protected, the client of the API (the web app) will refuse the SSL connection to the web API unless it trusts the API's SSL certificate.  Use the following steps in Windows Powershell to trust the IIS Express SSL certificate.  You only need to do this once.  If you fail to do this step, calls to the TodoListServiceMT will always throw an unhandled exception where the inner exception message is:
 
@@ -159,11 +147,11 @@ You can verify the certificate is in the Trusted Root store by running this comm
 `PS C:\windows\system32> dir Cert:\LocalMachine\Root`
 
 
-### Step 7:  [optional] Create an Azure Active Directory test tenant
+### Step 6:  [optional] Create an Azure Active Directory test tenant
 
 This sample shows how to take advantage of the consent model in Azure AD to make a web API available to native clients ran by any user from any organization with a tenant in Azure AD. To see that part of the sample in action, you need to have access to user accounts from a tenant that is different from the one you used for developing the application. The simplest way of doing that is to create a new directory tenant in your Azure subscription (just navigate to the main Active Directory page in the portal and click Add) and add test users. This step is optional as you can also run the sample with accounts from the same directory, but if you do you will not see the consent prompts as the app is already approved. 
 
-### Step 8:  Run the sample
+### Step 7:  Run the sample
 
 Clean the solution, rebuild the solution, and run it.  You might want to go into the solution properties and set both projects as startup projects, with the service project starting first.
 
@@ -196,4 +184,3 @@ Coming soon.
 ## How To Recreate This Sample
 
 Coming soon.
-


### PR DESCRIPTION
By default, Azure creates new native apps with visibility only to the tenant who owns the app registration. Unlike the web app, Azure does not provide a straightforward toggle for this.

For this sample to work in its entirety (i.e. against another tenant), an additional step is required to configure the native app for multitenancy.